### PR TITLE
Migrated from Java EE 8 to Jakarta EE 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenBank
 
-A demonstration of an simple bank application made with Java Enterprise Edition 8 platform (not JAKARTA EE) for the 
+A demonstration of an simple bank application made with Jakarta Enterprise Edition 8 platform (Java EE) for the 
 backend part and with Angular 7 for the frontend part.
 
 [![Build Status](https://travis-ci.org/jsquad-consulting/openbank-jee.svg?branch=master)](https://travis-ci.org/jsquad-consulting/openbank-jee)

--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,10 @@
 	</modules>
 
     <properties>
+        <rest.assured.version>4.0.0</rest.assured.version>
+        <swagger.request.validator.restassured.version>2.4.1</swagger.request.validator.restassured.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <junit.jupiter.version>5.4.0</junit.jupiter.version>
-        <mockito.version>2.25.0</mockito.version>
         <!-- Sonar -->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
@@ -51,7 +51,7 @@
         <sonar.jacoco.itReportPaths>${project.basedir}/../target/jacoco-it.exec</sonar.jacoco.itReportPaths>
         <sonar.language>java</sonar.language>
         <maven.surefire.version>2.22.2</maven.surefire.version>
-        <java.ee.version>8.0</java.ee.version>
+        <java.ee.version>8.0.0</java.ee.version>
         <jacoco.version>0.8.4</jacoco.version>
     </properties>
 
@@ -77,14 +77,8 @@
     <dependencies>
         <!-- Java EE 8 -->
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>${java.ee.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <version>${java.ee.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -105,14 +99,14 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>eclipselink</artifactId>
-            <version>2.7.4</version>
+            <version>2.7.5</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>6.0.0</version>
+            <version>6.1.0</version>
         </dependency>
 
         <!-- Test dependicies -->
@@ -125,7 +119,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.15.Final</version>
+            <version>6.0.17.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -145,77 +139,65 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.12.0</version>
+            <version>1.12.4</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.6</version>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${rest.assured.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <version>4.0.0</version>
+            <artifactId>json-path</artifactId>
+            <version>${rest.assured.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>xml-path</artifactId>
+            <version>${rest.assured.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
             <groupId>com.atlassian.oai</groupId>
             <artifactId>swagger-request-validator-restassured</artifactId>
-            <version>2.4.1</version>
+            <version>${swagger.request.validator.restassured.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-junit</artifactId>
-            <version>2.7.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
+            <version>2.10.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>${mockito.version}</version>
+            <version>3.2.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -223,7 +205,7 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.28</version>
+            <version>2.29.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -30,15 +30,10 @@
 
 
 	<properties>
-		<maven.surefire.version>2.22.2</maven.surefire.version>
-		<rest.assured.version>4.0.0</rest.assured.version>
-		<swagger.request.validator.restassured.version>2.4.1</swagger.request.validator.restassured.version>
-		<jaxb2.basics.version>1.11.1</jaxb2.basics.version>
 		<swagger.annotations.version>1.5.21</swagger.annotations.version>
 		<springdoc.openapi.version>1.1.44</springdoc.openapi.version>
-		<spring.version>5.1.6.RELEASE</spring.version>
-		<junit.jupiter.version>5.4.2</junit.jupiter.version>
-		<org.testcontainers.version>1.12.2</org.testcontainers.version>
+		<spring.version>5.2.2.RELEASE</spring.version>
+		<log4j.version>2.12.1</log4j.version>
 	</properties>
 
 	<build>
@@ -118,12 +113,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.11.2</version>
+			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.11.2</version>
+			<version>${log4j.version}</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>log4j-api</artifactId>
@@ -134,7 +129,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-jcl</artifactId>
-			<version>2.11.2</version>
+			<version>${log4j.version}</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>log4j-api</artifactId>
@@ -150,7 +145,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.11.2</version>
+			<version>${log4j.version}</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>log4j-api</artifactId>
@@ -204,67 +199,10 @@
 
 		<!-- Test -->
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${org.testcontainers.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<version>${spring.version}</version>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>2.21.0</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>io.rest-assured</groupId>
-			<artifactId>rest-assured</artifactId>
-			<version>${rest.assured.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>com.atlassian.oai</groupId>
-			<artifactId>swagger-request-validator-restassured</artifactId>
-			<version>${swagger.request.validator.restassured.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>io.rest-assured</groupId>
-			<artifactId>json-path</artifactId>
-			<version>${rest.assured.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>io.rest-assured</groupId>
-			<artifactId>xml-path</artifactId>
-			<version>${rest.assured.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
-
 </project>


### PR DESCRIPTION
Bumped versions of junit, artemis, gson, eclipselink,
hibernate-validator, flyway and mockito.

Cleaned up dependency duplicates and moved them to parent pom
for common use mostly for unit/system tests.