### PR TITLE
Setup health metric spring actuator war module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,6 @@ COPY --from=module /root/.m2/repository/org/jasypt $WILDFLY_HOME/scripts/reposit
 
 COPY ear/target/openbank-1.0-SNAPSHOT.ear $WILDFLY_HOME/standalone/deployments/openbank-1.0-SNAPSHOT.ear
 
-EXPOSE 8080 9990
+EXPOSE 8080 9990 8081
 
-CMD ["/bin/bash", "-c", "/opt/jboss/wildfly/scripts/openbank_setup.sh && /opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0 -bmanagement 0.0.0.0"]
+CMD ["/bin/bash", "-c", "source /opt/jboss/wildfly/scripts/openbank_setup.sh && /opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0 -bmanagement 0.0.0.0"]

--- a/business/src/main/resources/META-INF/persistence.xml
+++ b/business/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 JSquad AB
+  ~ Copyright 2020 JSquad AB
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@
         <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
         <properties>
             <property name="javax.persistence.jdbc.driver" value="com.mysql.jdbc.Driver"/>
-            <property name="javax.persistence.jdbc.url" value="jdbc:mysql://openbankdb:3306/openbankdb"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:mysql://openbankdb:3306/openbank"/>
 
             <property name="eclipselink.logging.level" value="INFO"/>
             <property name="eclipselink.logging.level.sql" value="FINE"/>

--- a/configuration/jboss/template/standalone.xml
+++ b/configuration/jboss/template/standalone.xml
@@ -172,7 +172,7 @@
         <subsystem xmlns="urn:jboss:domain:datasources:5.0">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/OpenBankDS" pool-name="OpenBankDS">
-                    <connection-url>jdbc:mysql://openbankdb:3306/openbankdb?useSSL=false&amp;useUnicode=yes&amp;characterEncoding=UTF-8&amp;useJDBCCompliantTimezoneShift=true&amp;useLegacyDatetimeCode=false&amp;serverTimezone=UTC&amp;allowPublicKeyRetrieval=true</connection-url>
+                    <connection-url>jdbc:mysql://openbankdb:3306/openbank?useSSL=false&amp;useUnicode=yes&amp;characterEncoding=UTF-8&amp;useJDBCCompliantTimezoneShift=true&amp;useLegacyDatetimeCode=false&amp;serverTimezone=UTC&amp;allowPublicKeyRetrieval=true</connection-url>
                     <driver>mysql8</driver>
                     <security>
                         <user-name>hidden</user-name>
@@ -547,6 +547,7 @@
             <server name="default-server">
                 <http-listener name="default" socket-binding="http" redirect-socket="https" enable-http2="true"/>
                 <https-listener name="https" socket-binding="https" security-realm="ApplicationRealm" enable-http2="true"/>
+                <http-listener name="actuator" socket-binding="actuator" redirect-socket="https" enable-http2="true"/>
                 <host name="default-host" alias="localhost">
                     <location name="/" handler="welcome-content"/>
                     <http-invoker security-realm="ApplicationRealm"/>
@@ -587,6 +588,7 @@
         <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
         <socket-binding name="http" port="${jboss.http.port:8080}"/>
         <socket-binding name="https" port="${jboss.https.port:8443}"/>
+        <socket-binding name="actuator" port="8081"/>
         <socket-binding name="iiop" interface="unsecure" port="3528"/>
         <socket-binding name="iiop-ssl" interface="unsecure" port="3529"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>

--- a/docker-compose_local.yaml
+++ b/docker-compose_local.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 JSquad AB
+# Copyright 2020 JSquad AB
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ services:
   openbankdb:
     image: mysql:8.0.17
     environment:
-      MYSQL_DATABASE: 'openbankdb'
+      MYSQL_DATABASE: 'openbank'
       MYSQL_USER: ${OB_USER}
       MYSQL_PASSWORD: ${OB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${ROOT_PASSWORD}
@@ -38,6 +38,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - 8080:8080
+      - 8081:8081
       - 9990:9990
     links:
       - openbankdb

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2019 JSquad AB
+  ~ Copyright 2020 JSquad AB
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -35,6 +35,11 @@
                 <artifactId>maven-ear-plugin</artifactId>
                 <configuration>
                     <modules>
+                        <webModule>
+                            <groupId>se.jsquad</groupId>
+                            <artifactId>spring-actuator</artifactId>
+                            <contextRoot>/management</contextRoot>
+                        </webModule>
                         <webModule>
                             <groupId>se.jsquad</groupId>
                             <artifactId>spring</artifactId>
@@ -85,6 +90,12 @@
         <dependency>
             <groupId>se.jsquad</groupId>
             <artifactId>spring</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>se.jsquad</groupId>
+            <artifactId>spring-actuator</artifactId>
             <version>1.0-SNAPSHOT</version>
             <type>war</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2019 JSquad AB
+  ~ Copyright 2020 JSquad AB
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@
         <module>soap</module>
         <module>client</module>
 		<module>spring</module>
+        <module>spring-actuator</module>
 	</modules>
 
     <properties>
@@ -88,12 +89,6 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.17</version>
             <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jasypt</groupId>
-            <artifactId>jasypt</artifactId>
-            <version>1.9.3</version>
         </dependency>
 
         <dependency>

--- a/rest/src/test/resources/logback-test.xml
+++ b/rest/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT"/>
+	</root>
+
+	<logger name="org.testcontainers" level="INFO"/>
+	<logger name="com.github.dockerjava" level="WARN"/>
+</configuration>

--- a/spring-actuator/pom.xml
+++ b/spring-actuator/pom.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 JSquad AB
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>openbank-app</artifactId>
+		<groupId>se.jsquad</groupId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+
+	<groupId>se.jsquad</groupId>
+	<artifactId>spring-actuator</artifactId>
+	<packaging>war</packaging>
+
+	<properties>
+		<java.version>11</java.version>
+		<junit.jupiter.version>5.5.2</junit.jupiter.version>
+		<springdoc.openapi.version>1.1.49</springdoc.openapi.version>
+		<maven.surefire.version>2.22.2</maven.surefire.version>
+		<micrometer.version>1.3.2</micrometer.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<!-- Import dependency management from Spring Boot -->
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>2.1.8.RELEASE</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jdbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web-services</artifactId>
+			<exclusions>
+			<exclusion>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-tomcat</artifactId>
+			</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-logging</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<version>${micrometer.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.inject</groupId>
+			<artifactId>javax.inject</artifactId>
+			<version>1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>4.0.1</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>1.4.199</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>3.2.2</version>
+				<configuration>
+					<failOnMissingWebXml>false</failOnMissingWebXml>
+				</configuration>
+			</plugin>
+			<!-- JUnit 5 requires Surefire version 2.22.1 or higher -->
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven.surefire.version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>jaxb2-maven-plugin</artifactId>
+				<version>2.4</version>
+				<executions>
+					<execution>
+						<id>xjc</id>
+						<goals>
+							<goal>xjc</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<arguments>
+						<argument>-Xannotate</argument>
+					</arguments>
+					<extension>true</extension>
+					<sources>
+						<source>${project.basedir}/src/main/resources/schema/xsd/system-status.xsd</source>
+						<source>${project.basedir}/src/main/resources/schema/xsd/dummy.xsd</source>
+					</sources>
+					<clearOutputDir>false</clearOutputDir>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.springdoc</groupId>
+						<artifactId>springdoc-openapi-core</artifactId>
+						<version>${springdoc.openapi.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.jvnet.jaxb2_commons</groupId>
+						<artifactId>jaxb2-annotate-plugin-test-annox-annotations</artifactId>
+						<version>1.0.0</version>
+					</dependency>
+					<dependency>
+						<groupId>org.jvnet.jaxb2_commons</groupId>
+						<artifactId>jaxb2-basics-annotate</artifactId>
+						<version>1.0.2</version>
+					</dependency>
+					<dependency>
+						<groupId>org.glassfish.jaxb</groupId>
+						<artifactId>jaxb-xjc</artifactId>
+						<version>2.3.2</version>
+					</dependency>
+					<dependency>
+						<groupId>com.sun.activation</groupId>
+						<artifactId>jakarta.activation</artifactId>
+						<version>1.2.1</version>
+					</dependency>
+					<dependency>
+						<groupId>org.jvnet.jaxb2_commons</groupId>
+						<artifactId>jaxb2-fluent-api</artifactId>
+						<version>3.0</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+		<outputDirectory>${project.build.directory}/${project.build.finalName}/WEB-INF/classes</outputDirectory>
+	</build>
+</project>

--- a/spring-actuator/src/main/java/se/jsquad/OpenbankSpringApplication.java
+++ b/spring-actuator/src/main/java/se/jsquad/OpenbankSpringApplication.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+@SpringBootApplication
+public class OpenbankSpringApplication extends SpringBootServletInitializer {
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder builder){
+        return builder.sources(OpenbankSpringApplication.class);
+    }
+
+    public static void main(String[] args){
+        SpringApplication.run(OpenbankSpringApplication.class, args);
+    }
+}

--- a/spring-actuator/src/main/java/se/jsquad/actuator/DeepSystemStatusIndicator.java
+++ b/spring-actuator/src/main/java/se/jsquad/actuator/DeepSystemStatusIndicator.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.actuator;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import se.jsquad.health.check.DeepSystemStatusResponse;
+import se.jsquad.health.check.Dependencies;
+import se.jsquad.health.check.HealthStatus;
+import se.jsquad.health.check.ShallowSystemStatusResponse;
+
+@Component
+@Endpoint(id = "deephealth")
+public class DeepSystemStatusIndicator {
+    private Logger logger;
+
+    private ShallowSystemStatusIndicator shallowSystemStatusIndicator;
+    private HealthIndicator openbankDatabaseHealthIndicator;
+    private Gauge gaugeDeepHealth;
+    private Gauge gaugeService;
+    private Gauge gaugeOpenBankDatabase;
+
+    public DeepSystemStatusIndicator(Logger logger,
+                                     ShallowSystemStatusIndicator shallowSystemStatusIndicator,
+                                     @Qualifier("openbankDatabaseHealthIndicator")
+                                             HealthIndicator openbankDatabaseHealthIndicator,
+                                     MeterRegistry meterRegistry) {
+        this.logger = logger;
+        this.shallowSystemStatusIndicator = shallowSystemStatusIndicator;
+        this.openbankDatabaseHealthIndicator = openbankDatabaseHealthIndicator;
+
+        gaugeDeepHealth = Gauge.builder("deep_health", this,
+                deepSystemStatusIndicator -> "UP".equals(deepSystemStatusIndicator.getDeepSystemStatus()
+                        .getBody().getStatus().value()) ? 1 : 0)
+                .strongReference(true)
+                .description("Deep health of this service and it's dependencies")
+                .tags(Tags.of("status", "up"))
+                .register(meterRegistry);
+
+        gaugeService = Gauge.builder("deep_health_service", shallowSystemStatusIndicator,
+                s -> "UP".equals(s.getShallowSystemStatus().getBody().getStatus().value()) ? 1 : 0)
+                .strongReference(true)
+                .description("Health of just this service")
+                .tags(Tags.of("status", "up"))
+                .register(meterRegistry);
+
+        gaugeOpenBankDatabase = Gauge.builder("deep_health_openbank_database", openbankDatabaseHealthIndicator,
+                o -> "UP".equals(o.health().getStatus().getCode()) ? 1 : 0)
+                .strongReference(true)
+                .description("Health of the openbank database")
+                .tags(Tags.of("status", "up"))
+                .register(meterRegistry);
+    }
+
+    @ReadOperation
+    public ResponseEntity<DeepSystemStatusResponse> getDeepSystemStatus() {
+        return ResponseEntity.ok(checkDeepSystemStatus());
+    }
+
+    private DeepSystemStatusResponse checkDeepSystemStatus() {
+        DeepSystemStatusResponse deepSystemStatusResponse = new DeepSystemStatusResponse();
+
+        deepSystemStatusResponse.setStatus(HealthStatus.DOWN);
+
+        ResponseEntity<ShallowSystemStatusResponse> responseEntity = shallowSystemStatusIndicator
+                .getShallowSystemStatus();
+
+        if (responseEntity.getStatusCode().is2xxSuccessful()
+                && HealthStatus.UP.equals(responseEntity.getBody().getStatus())) {
+            deepSystemStatusResponse.setService(responseEntity.getBody().getStatus());
+        } else {
+            deepSystemStatusResponse.setService(HealthStatus.DOWN);
+        }
+
+        Dependencies dependencies = new Dependencies();
+        deepSystemStatusResponse.setDependencies(dependencies);
+
+        dependencies.setOpenbankDb(HealthStatus.DOWN);
+
+        dependencies.setOpenbankDb(HealthStatus.fromValue(openbankDatabaseHealthIndicator.health()
+                .getStatus().getCode()));
+
+        if (HealthStatus.UP.equals(dependencies.getOpenbankDb())
+                && HealthStatus.UP.equals(deepSystemStatusResponse.getService())) {
+            deepSystemStatusResponse.setStatus(HealthStatus.UP);
+        }
+
+        gaugeDeepHealth.measure();
+        gaugeService.measure();
+        gaugeOpenBankDatabase.measure();
+
+        return deepSystemStatusResponse;
+    }
+}

--- a/spring-actuator/src/main/java/se/jsquad/actuator/ShallowSystemStatusIndicator.java
+++ b/spring-actuator/src/main/java/se/jsquad/actuator/ShallowSystemStatusIndicator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.actuator;
+
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import se.jsquad.health.check.HealthStatus;
+import se.jsquad.health.check.ShallowSystemStatusResponse;
+
+@Component
+@Endpoint(id = "shallowhealth")
+public class ShallowSystemStatusIndicator {
+    private Logger logger;
+
+    private HealthIndicator diskSpaceHealthIndicator;
+
+    public ShallowSystemStatusIndicator(Logger logger,
+                                        @Qualifier("diskSpaceHealthIndicator")
+                                       HealthIndicator diskSpaceHealthIndicator) {
+        this.logger = logger;
+        this.diskSpaceHealthIndicator = diskSpaceHealthIndicator;
+    }
+
+    @ReadOperation
+    public ResponseEntity<ShallowSystemStatusResponse> getShallowSystemStatus() {
+        return ResponseEntity.ok(checkShallowSystemStatus());
+    }
+
+    private ShallowSystemStatusResponse checkShallowSystemStatus() {
+        ShallowSystemStatusResponse shallowSystemStatusResponse = new ShallowSystemStatusResponse();
+
+        shallowSystemStatusResponse.setStatus(HealthStatus.fromValue(diskSpaceHealthIndicator.health()
+                .getStatus().getCode()));
+
+        return shallowSystemStatusResponse;
+    }
+}

--- a/spring-actuator/src/main/java/se/jsquad/component/database/DatabaseConfiguration.java
+++ b/spring-actuator/src/main/java/se/jsquad/component/database/DatabaseConfiguration.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.component.database;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public class DatabaseConfiguration {
+    @NotNull
+    @NotEmpty
+    private String url;
+
+    @NotNull
+    @NotEmpty
+    private String username;
+
+    @NotNull
+    @NotEmpty
+    private String password;
+
+    @NotNull
+    @NotEmpty
+    private String driverclassname;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getDriverclassname() {
+        return driverclassname;
+    }
+
+    public void setDriverclassname(String driverclassname) {
+        this.driverclassname = driverclassname;
+    }
+}

--- a/spring-actuator/src/main/java/se/jsquad/component/database/OpenBankDatabaseConfiguration.java
+++ b/spring-actuator/src/main/java/se/jsquad/component/database/OpenBankDatabaseConfiguration.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.component.database;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "openbank.datasource")
+public class OpenBankDatabaseConfiguration extends DatabaseConfiguration {
+}

--- a/spring-actuator/src/main/java/se/jsquad/configuration/ApplicationConfiguration.java
+++ b/spring-actuator/src/main/java/se/jsquad/configuration/ApplicationConfiguration.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.configuration;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.InjectionPoint;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.jdbc.DataSourceHealthIndicator;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.jdbc.core.JdbcTemplate;
+import se.jsquad.component.database.OpenBankDatabaseConfiguration;
+
+@Configuration
+@ComponentScan(basePackages = {"se.jsquad"})
+@EnableConfigurationProperties(value = {OpenBankDatabaseConfiguration.class})
+public class ApplicationConfiguration {
+    private OpenBankDatabaseConfiguration openBankDatabaseConfiguration;
+
+    public ApplicationConfiguration(OpenBankDatabaseConfiguration openBankDatabaseConfiguration) {
+        this.openBankDatabaseConfiguration = openBankDatabaseConfiguration;
+    }
+
+    @Bean("logger")
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    Logger getLogger(final InjectionPoint injectionPoint) {
+        return LogManager.getLogger(injectionPoint.getMember().getDeclaringClass().getName());
+    }
+
+    @Bean
+    @Qualifier("openBankJdbcTemplate")
+    public JdbcTemplate openBankJdbcTemplate() {
+        DataSourceBuilder dataSourceBuilder = DataSourceBuilder.create();
+        dataSourceBuilder.driverClassName(openBankDatabaseConfiguration.getDriverclassname());
+        dataSourceBuilder.url(openBankDatabaseConfiguration.getUrl());
+
+        dataSourceBuilder.username(System.getenv("OB_USER"));
+        dataSourceBuilder.password(System.getenv("OB_PASSWORD"));
+
+        return new JdbcTemplate(dataSourceBuilder.build(), true);
+    }
+
+    @Bean("openbankDatabaseHealthIndicator")
+    public HealthIndicator openbankDatabaseHealthIndicator() {
+        DataSourceHealthIndicator dataSourceHealthIndicator =
+                new DataSourceHealthIndicator(openBankJdbcTemplate().getDataSource());
+
+        dataSourceHealthIndicator.setQuery("SELECT 1");
+
+        return dataSourceHealthIndicator;
+    }
+}

--- a/spring-actuator/src/main/resources/application.yaml
+++ b/spring-actuator/src/main/resources/application.yaml
@@ -1,0 +1,43 @@
+#
+# Copyright 2020 JSquad AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring:
+  flyway:
+    enabled: false
+
+openbank.datasource:
+  url: jdbc:mysql://openbankdb:3306/openbank
+  username: secret
+  password: secret
+  driverclassname: com.mysql.cj.jdbc.Driver
+
+logging.level:
+  root: INFO
+  org.springframework.web: INFO
+  org.hibernate: ERROR
+  com.howtoprogram: DEBUG
+
+management.endpoint:
+  prometheus:
+    enabled: true
+  metrics.enabled: true
+
+management.endpoints:
+  web:
+    base-path: /actuator
+    exposure.include: 'shallowhealth,deephealth,metrics,prometheus'
+
+management.metrics.export.prometheus.enabled: true

--- a/spring-actuator/src/main/resources/schema/xsd/dummy.xsd
+++ b/spring-actuator/src/main/resources/schema/xsd/dummy.xsd
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2020 JSquad AB
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema id="Dummy" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="Dummy">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="test"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/spring-actuator/src/main/resources/schema/xsd/global.xjb
+++ b/spring-actuator/src/main/resources/schema/xsd/global.xjb
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<jaxb:bindings version="2.1"
+  xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+  xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:annox="http://annox.dev.java.net"
+  jaxb:extensionBindingPrefixes="xjc"
+  schemaLocation="./system-status.xsd"
+  node="//xs:schema">
+
+</jaxb:bindings>

--- a/spring-actuator/src/main/resources/schema/xsd/system-status.xsd
+++ b/spring-actuator/src/main/resources/schema/xsd/system-status.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Copyright 2020 JSquad AB
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		   xmlns:tns="http://jsquad.se/health/check"
+		   xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+		   jaxb:version="2.1"
+		   xmlns:annox="http://annox.dev.java.net"
+		   targetNamespace="http://jsquad.se/health/check" version="1.0"
+		   jaxb:extensionBindingPrefixes="annox">
+
+	<xs:complexType name="DeepSystemStatusResponse">
+		<xs:sequence>
+			<xs:element name="status" type="tns:HealthStatus"/>
+			<xs:element name="service" type="tns:HealthStatus"/>
+			<xs:element name="dependencies" type="tns:Dependencies"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="ShallowSystemStatusResponse">
+		<xs:sequence>
+			<xs:element name="status" type="tns:HealthStatus"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Dependencies">
+		<xs:sequence>
+			<xs:element name="openbank-db" type="tns:HealthStatus"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:simpleType name="HealthStatus">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DOWN"/>
+			<xs:enumeration value="UP"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/spring-actuator/src/test/java/se/jsquad/actuator/DeepSystemStatusIndicatorTest.java
+++ b/spring-actuator/src/test/java/se/jsquad/actuator/DeepSystemStatusIndicatorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.actuator;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import se.jsquad.health.check.DeepSystemStatusResponse;
+import se.jsquad.health.check.HealthStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@TestPropertySource(locations = {"classpath:test/application.properties"})
+public class DeepSystemStatusIndicatorTest {
+    private Gson gson = new Gson();
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Test
+    public void testDeepSystemStatus() throws Exception {
+        // Given
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+        // When and then
+        MvcResult mvcResult =
+                mockMvc.perform(get("/actuator/deephealth").contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk()).andReturn();
+
+        DeepSystemStatusResponse deepSystemStatusResponse =
+                gson.fromJson(mvcResult.getResponse().getContentAsString(), DeepSystemStatusResponse.class);
+
+        assertEquals(HealthStatus.UP, deepSystemStatusResponse.getStatus());
+
+    }
+}

--- a/spring-actuator/src/test/java/se/jsquad/actuator/ShallowSystemStatusIndicatorTest.java
+++ b/spring-actuator/src/test/java/se/jsquad/actuator/ShallowSystemStatusIndicatorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.actuator;
+
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import se.jsquad.health.check.HealthStatus;
+import se.jsquad.health.check.ShallowSystemStatusResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@TestPropertySource(locations = {"classpath:test/application.properties"})
+public class ShallowSystemStatusIndicatorTest {
+    private Gson gson = new Gson();
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Test
+    public void testShallowSystemStatus() throws Exception {
+        // Given
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+        // When and then
+        MvcResult mvcResult =
+                mockMvc.perform(get("/actuator/shallowhealth").contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()).andReturn();
+
+        ShallowSystemStatusResponse shallowSystemStatusResponse =
+                gson.fromJson(mvcResult.getResponse().getContentAsString(), ShallowSystemStatusResponse.class);
+
+        assertEquals(HealthStatus.UP, shallowSystemStatusResponse.getStatus());
+
+    }
+}

--- a/spring-actuator/src/test/java/se/jsquad/component/database/OpenBankDatabaseConfigurationTest.java
+++ b/spring-actuator/src/test/java/se/jsquad/component/database/OpenBankDatabaseConfigurationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.component.database;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OpenBankDatabaseConfigurationTest {
+    @Test
+    public void testDatabaseConfigurationFieldConstraints() {
+        // Given
+        DatabaseConfiguration openBankDatabaseConfiguration = new OpenBankDatabaseConfiguration();
+
+        // When
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        Set<ConstraintViolation<DatabaseConfiguration>> constraintViolationSet = validator
+                .validate(openBankDatabaseConfiguration);
+
+        // Then
+        assertEquals(8, constraintViolationSet.size());
+
+        Optional<ConstraintViolation<DatabaseConfiguration>> constraintViolationOptional =
+                constraintViolationSet.stream()
+                        .filter(databaseConfigurationConstraintViolation1 -> "must not be null"
+                                .equals(databaseConfigurationConstraintViolation1.getMessage())
+                                && "url".equals(databaseConfigurationConstraintViolation1.getPropertyPath()
+                                .toString()))
+                        .findFirst();
+
+        assertTrue(constraintViolationOptional.isPresent());
+
+
+        constraintViolationOptional =
+                constraintViolationSet.stream()
+                        .filter(databaseConfigurationConstraintViolation1 -> "must not be empty"
+                                .equals(databaseConfigurationConstraintViolation1.getMessage())
+                                && "url".equals(databaseConfigurationConstraintViolation1.getPropertyPath()
+                                .toString())).findFirst();
+
+        assertTrue(constraintViolationOptional.isPresent());
+
+        constraintViolationOptional =
+                constraintViolationSet.stream()
+                        .filter(databaseConfigurationConstraintViolation1 -> "must not be null"
+                                .equals(databaseConfigurationConstraintViolation1.getMessage())
+                                && "username".equals(databaseConfigurationConstraintViolation1.getPropertyPath()
+                                .toString())).findFirst();
+
+        assertTrue(constraintViolationOptional.isPresent());
+
+
+        constraintViolationOptional =
+                constraintViolationSet.stream()
+                        .filter(databaseConfigurationConstraintViolation1 -> "must not be empty"
+                                .equals(databaseConfigurationConstraintViolation1.getMessage())
+                                && "username".equals(databaseConfigurationConstraintViolation1.getPropertyPath()
+                                .toString())).findFirst();
+
+        assertTrue(constraintViolationOptional.isPresent());
+
+        constraintViolationOptional =
+                constraintViolationSet.stream()
+                        .filter(databaseConfigurationConstraintViolation1 -> "must not be null".equals(
+                                databaseConfigurationConstraintViolation1.getMessage()) &&
+                                "password".equals(databaseConfigurationConstraintViolation1.getPropertyPath()
+                                        .toString())).findFirst();
+
+        assertTrue(constraintViolationOptional.isPresent());
+
+
+        constraintViolationOptional =
+                constraintViolationSet.stream()
+                        .filter(databaseConfigurationConstraintViolation1 -> "must not be empty"
+                                .equals(databaseConfigurationConstraintViolation1.getMessage())
+                                && "password".equals(databaseConfigurationConstraintViolation1.getPropertyPath()
+                                .toString())).findFirst();
+
+        assertTrue(constraintViolationOptional.isPresent());
+
+        constraintViolationOptional =
+                constraintViolationSet.stream()
+                        .filter(databaseConfigurationConstraintViolation1 -> "must not be null"
+                                .equals(databaseConfigurationConstraintViolation1.getMessage())
+                                && "driverclassname".equals(databaseConfigurationConstraintViolation1.getPropertyPath()
+                                .toString())).findFirst();
+
+        assertTrue(constraintViolationOptional.isPresent());
+
+
+        constraintViolationOptional =
+                constraintViolationSet.stream()
+                        .filter(databaseConfigurationConstraintViolation1 -> "must not be empty"
+                                .equals(databaseConfigurationConstraintViolation1.getMessage())
+                                && "driverclassname".equals(databaseConfigurationConstraintViolation1.getPropertyPath()
+                                .toString()))
+                        .findFirst();
+
+        assertTrue(constraintViolationOptional.isPresent());
+
+        // Given
+        openBankDatabaseConfiguration.setDriverclassname("test");
+        openBankDatabaseConfiguration.setPassword("test");
+        openBankDatabaseConfiguration.setUsername("test");
+        openBankDatabaseConfiguration.setUrl("test");
+
+        // When and then
+        assertEquals(0, validator.validate(openBankDatabaseConfiguration).size());
+    }
+}

--- a/spring-actuator/src/test/java/se/jsquad/integration/DeepAndShallowHealthCheckOkIT.java
+++ b/spring-actuator/src/test/java/se/jsquad/integration/DeepAndShallowHealthCheckOkIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.integration;
+
+import com.google.gson.Gson;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import se.jsquad.health.check.DeepSystemStatusResponse;
+import se.jsquad.health.check.HealthStatus;
+import se.jsquad.health.check.ShallowSystemStatusResponse;
+
+import java.io.File;
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+@Execution(ExecutionMode.SAME_THREAD)
+public class DeepAndShallowHealthCheckOkIT {
+    private Gson gson = new Gson();
+
+    private static int servicePort = 8081;
+
+    private static DockerComposeContainer dockerComposeContainer = new DockerComposeContainer(
+            new File("src/test/resources/docker-compose-int.yaml"))
+            .withExposedService("openbank_1", servicePort)
+            .withPull(false)
+            .withTailChildContainers(true)
+            .withLocalCompose(true);
+
+    @BeforeAll
+    static void setupDocker() {
+        dockerComposeContainer.start();
+
+        RestAssured.baseURI = "http://" + dockerComposeContainer.getServiceHost("openbank_1", servicePort);
+        RestAssured.port = dockerComposeContainer.getServicePort("openbank_1", servicePort);
+        RestAssured.basePath = "/management/actuator";
+    }
+
+    @AfterAll
+    static void destroyDocker() {
+        dockerComposeContainer.stop();
+    }
+
+    @Test
+    public void testShallowHealthCheck() {
+        // When
+        Response response = RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .get(URI.create("/shallowhealth")).andReturn();
+
+        // Then
+        ShallowSystemStatusResponse shallowSystemStatusResponse = gson.fromJson(response.getBody().asString(),
+                ShallowSystemStatusResponse.class);
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(HealthStatus.UP, shallowSystemStatusResponse.getStatus());
+    }
+
+    @Test
+    public void testDeepHealthCheck() {
+        // When
+        Response response = RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .get(URI.create("/deephealth")).andReturn();
+
+        // Then
+        DeepSystemStatusResponse deepSystemStatusResponse = gson.fromJson(response.getBody().asString(),
+                DeepSystemStatusResponse.class);
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(HealthStatus.UP, deepSystemStatusResponse.getService());
+        assertEquals(HealthStatus.UP, deepSystemStatusResponse.getDependencies().getOpenbankDb());
+        assertEquals(HealthStatus.UP, deepSystemStatusResponse.getStatus());
+    }
+}

--- a/spring-actuator/src/test/java/se/jsquad/integration/DeepHealthCheckNotOkIT.java
+++ b/spring-actuator/src/test/java/se/jsquad/integration/DeepHealthCheckNotOkIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.integration;
+
+import com.google.gson.Gson;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import se.jsquad.health.check.DeepSystemStatusResponse;
+import se.jsquad.health.check.HealthStatus;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Testcontainers
+@Execution(ExecutionMode.SAME_THREAD)
+public class DeepHealthCheckNotOkIT {
+    private Gson gson = new Gson();
+
+    private static int servicePort = 8081;
+
+    private static DockerComposeContainer dockerComposeContainer = new DockerComposeContainer(
+            new File("src/test/resources/docker-compose-int.yaml"))
+            .withExposedService("openbank_1", servicePort)
+            .withPull(false)
+            .withTailChildContainers(true)
+            .withLocalCompose(true);
+
+    @BeforeAll
+    static void setupDocker() {
+        dockerComposeContainer.start();
+
+        RestAssured.baseURI = "http://" + dockerComposeContainer.getServiceHost("openbank_1", servicePort);
+        RestAssured.port = dockerComposeContainer.getServicePort("openbank_1", servicePort);
+        RestAssured.basePath = "/management/actuator";
+    }
+
+    @AfterAll
+    static void destroyDocker() {
+        dockerComposeContainer.stop();
+    }
+
+    @Test
+    public void testDeepHealthCheckNotOk() throws NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException {
+        // Given
+        Method method = DockerComposeContainer.class.getDeclaredMethod("runWithCompose", String.class);
+        method.setAccessible(true);
+        method.invoke(dockerComposeContainer, "kill openbankdb");
+
+        // When
+        Response response = RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .get(URI.create("/deephealth")).andReturn();
+
+        // Then
+        DeepSystemStatusResponse deepSystemStatusResponse = gson.fromJson(response.getBody().asString(),
+                DeepSystemStatusResponse.class);
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(HealthStatus.DOWN, deepSystemStatusResponse.getStatus());
+        assertEquals(HealthStatus.UP, deepSystemStatusResponse.getService());
+        assertEquals(HealthStatus.DOWN, deepSystemStatusResponse.getDependencies().getOpenbankDb());
+    }
+}

--- a/spring-actuator/src/test/java/se/jsquad/integration/MonitorPrometheusDownStatusIT.java
+++ b/spring-actuator/src/test/java/se/jsquad/integration/MonitorPrometheusDownStatusIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.integration;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Testcontainers
+@Execution(ExecutionMode.SAME_THREAD)
+public class MonitorPrometheusDownStatusIT {
+    private static int servicePort = 8081;
+
+    private static DockerComposeContainer dockerComposeContainer = new DockerComposeContainer(
+            new File("src/test/resources/docker-compose-int.yaml"))
+            .withExposedService("openbank_1", servicePort)
+            .withPull(false)
+            .withTailChildContainers(true)
+            .withLocalCompose(true);
+
+    @BeforeAll
+    static void setupDocker() {
+        dockerComposeContainer.start();
+
+        RestAssured.baseURI = "http://" + dockerComposeContainer.getServiceHost("openbank_1", servicePort);
+        RestAssured.port = dockerComposeContainer.getServicePort("openbank_1", servicePort);
+        RestAssured.basePath = "/management/actuator";
+    }
+
+    @AfterAll
+    static void destroyDocker() {
+        dockerComposeContainer.stop();
+    }
+
+    @Test
+    public void testDeepHealthMetricsNotOk() throws NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException {
+        // Given
+        Method method = DockerComposeContainer.class.getDeclaredMethod("runWithCompose", String.class);
+        method.setAccessible(true);
+        method.invoke(dockerComposeContainer, "kill openbankdb");
+
+        // When
+        Response response = RestAssured
+                .given()
+                .contentType(ContentType.ANY)
+                .accept(ContentType.ANY)
+                .when()
+                .get(URI.create("/prometheus")).andReturn();
+
+        // Then
+        assertEquals(200, response.getStatusCode());
+
+        assertTrue(response.getBody().asString().contains("deep_health{status=\"up\",} 0.0"));
+        assertTrue(response.getBody().asString().contains("deep_health_service{status=\"up\",} 1.0"));
+        assertTrue(response.getBody().asString().contains("deep_health_openbank_database{status=\"up\",} 0.0"));
+    }
+}

--- a/spring-actuator/src/test/java/se/jsquad/integration/MonitorPrometheusUpStatusIT.java
+++ b/spring-actuator/src/test/java/se/jsquad/integration/MonitorPrometheusUpStatusIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 JSquad AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.jsquad.integration;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.File;
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Testcontainers
+@Execution(ExecutionMode.SAME_THREAD)
+public class MonitorPrometheusUpStatusIT {
+    private static int servicePort = 8081;
+
+    private static DockerComposeContainer dockerComposeContainer = new DockerComposeContainer(
+            new File("src/test/resources/docker-compose-int.yaml"))
+            .withExposedService("openbank_1", servicePort)
+            .withPull(false)
+            .withTailChildContainers(true)
+            .withLocalCompose(true);
+
+    @BeforeAll
+    static void setupDocker() {
+        dockerComposeContainer.start();
+
+        RestAssured.baseURI = "http://" + dockerComposeContainer.getServiceHost("openbank_1", servicePort);
+        RestAssured.port = dockerComposeContainer.getServicePort("openbank_1", servicePort);
+        RestAssured.basePath = "/management/actuator";
+    }
+
+    @AfterAll
+    static void destroyDocker() {
+        dockerComposeContainer.stop();
+    }
+
+    @Test
+    public void testDeepHealthMetricsOk() {
+        // When
+        Response response = RestAssured
+                .given()
+                .contentType(ContentType.ANY)
+                .accept(ContentType.ANY)
+                .when()
+                .get(URI.create("/prometheus")).andReturn();
+
+        // Then
+        assertEquals(200, response.getStatusCode());
+
+        assertTrue(response.getBody().asString().contains("deep_health{status=\"up\",} 1.0"));
+        assertTrue(response.getBody().asString().contains("deep_health_service{status=\"up\",} 1.0"));
+        assertTrue(response.getBody().asString().contains("deep_health_openbank_database{status=\"up\",} 1.0"));
+    }
+}

--- a/spring-actuator/src/test/resources/docker-compose-int.yaml
+++ b/spring-actuator/src/test/resources/docker-compose-int.yaml
@@ -24,7 +24,7 @@ services:
       MYSQL_PASSWORD: ${OB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${ROOT_PASSWORD}
     expose:
-      - 3306
+      - "3306"
     cap_add:
       - SYS_NICE
     healthcheck:
@@ -34,19 +34,18 @@ services:
   openbank:
     image: openbank
     build:
-      context: .
+      context: ../../../../
       dockerfile: Dockerfile
-    ports:
-      - 8080:8080
-      - 8081:8081
-      - 9990:9990
+    expose:
+      - "8080"
+      - "8081"
     links:
       - openbankdb
     depends_on:
       - openbankdb
     restart: on-failure
     environment:
-      MASTER_KEY: ${MASTER_KEY}
+      MASTER_KEY: "test"
     volumes:
-    - ./openbank_setup_prod.sh:/opt/jboss/wildfly/scripts/openbank_setup.sh
-    - ./configuration/properties_prod.properties:/opt/jboss/wildfly/scripts/properties.properties
+      - ../../../../openbank_setup_local.sh:/opt/jboss/wildfly/scripts/openbank_setup.sh
+      - ../../../../configuration/properties_local.properties:/opt/jboss/wildfly/scripts/properties.properties

--- a/spring-actuator/src/test/resources/junit-platform.properties
+++ b/spring-actuator/src/test/resources/junit-platform.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2020 JSquad AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=dynamic

--- a/spring-actuator/src/test/resources/logback-test.xml
+++ b/spring-actuator/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT"/>
+	</root>
+
+	<logger name="org.testcontainers" level="INFO"/>
+	<logger name="com.github.dockerjava" level="WARN"/>
+</configuration>

--- a/spring-actuator/src/test/resources/test/application.properties
+++ b/spring-actuator/src/test/resources/test/application.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2020 JSquad AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring.flyway.enabled=false
+
+openbank.datasource.url=jdbc:h2:mem:openbank
+openbank.datasource.username=openbank_user
+openbank.datasource.password=openbank_password
+openbank.datasource.driverclassname=org.h2.Driver
+
+management.endpoint.prometheus.enabled=true
+management.endpoint.metrics.enabled=true
+
+management.endpoints.web.base-path=/actuator
+management.endpoints.web.exposure.include=shallowhealth,deephealth,metrics,prometheus
+
+management.metrics.export.prometheus.enabled: true
+spring.main.allow-bean-definition-overriding=true

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 JSquad AB
+  ~ Copyright 2020 JSquad AB
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -81,13 +81,6 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
 			<version>${spring.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
-			<version>${spring.version}</version>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Added port 8081 to actuator management endpoint.

Added integration tests for testing health metrics for shallow and
deep health and prometheus scraping and related Docker Compose file.

Added system tests for the deep and shallow health indicator
endpoints.

Updated OpenBankDb datasource to use openbank mysql database name.

Updated Docker and Docker Compose files to expose port 8081 for
testing actuator health check endpoints and metrics for
prometheus.

Added logback for integration tests for better logging.

Setup Spring Boot 2 spring-actuator configuration with configured
mysql datasource and health checks for shallow and deep endpoints.

Added application.properties to the spring-actuator module system
tests.

Added jasypt to enable decryption of the encrypted property files.

Updated spring-actuator application configuration to read the username and
password from the system environment instead.

Updated Dockerfile to set permanent environment variables.

Cleaned up jasypt dependencies because it's used internally by
Wildfly container setup.